### PR TITLE
Fix SetVolume for systems with more than two channels

### DIFF
--- a/Source/Agents/Output/CoreAudio/CoreAudioWorker.cs
+++ b/Source/Agents/Output/CoreAudio/CoreAudioWorker.cs
@@ -575,10 +575,12 @@ namespace Polycode.NostalgicPlayer.Agent.Output.CoreAudio
 		/********************************************************************/
 		private void SetVolume()
 		{
-			if (outputFormat.Channels == 1)
-				audioClient.AudioStreamVolume.SetAllVolumes(new[] { currentVolume });
-			else
-				audioClient.AudioStreamVolume.SetAllVolumes(new[] { currentVolume, currentVolume });
+			float[] volumes = new float[audioClient.AudioStreamVolume.ChannelCount];
+			for (int i = 0; i < volumes.Length; ++i)
+			{
+				volumes[i] = currentVolume;
+			}
+			audioClient.AudioStreamVolume.SetAllVolumes(volumes);
 		}
 
 


### PR DESCRIPTION
I got a System.ArgumentOutOfRangeException when trying to play a file with the exception-message "SetAllVolumes MUST be supplied with a volume level for ALL channels. The AudioStream has 8 channels and you supplied 2 channels. (Parameter 'levels')".
outputFormat.Channels was also just 2 for me so I use audioClient.AudioStreamVolume.ChannelCount instead.