### PR TITLE
Fix GitHub build actions

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -14,10 +14,6 @@ jobs:
         with:
           lfs: 'true'
       - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v1
-      - name: Setup NuGet
-        uses: NuGet/setup-nuget@v1.0.2
-      - name: Install dependencies
-        run: nuget restore Source\NostalgicPlayer.sln
+        uses: microsoft/setup-msbuild@v2
       - name: Build
-        run: msbuild Source\NostalgicPlayer.sln /nologo /nr:false /p:configuration="Release" /p:Platform="Any CPU"
+        run: msbuild Source\NostalgicPlayer.sln -t:rebuild -property:configuration="Release" -property:Platform="Any CPU"

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -4,10 +4,6 @@ on: push
 jobs:
   Build_Release:
     runs-on: windows-latest
-    strategy:
-      matrix:
-        dotnet-version: [ '8.0.x' ]
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -15,5 +15,8 @@ jobs:
           lfs: 'true'
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v2
+      - name: Install dependencies
+        uses: nuget/setup-nuget@v2
+        run: nuget restore Source\NostalgicPlayer.sln
       - name: Build
         run: msbuild Source\NostalgicPlayer.sln -t:rebuild -property:configuration="Release" -property:Platform="Any CPU"

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -15,8 +15,9 @@ jobs:
           lfs: 'true'
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v2
-      - name: Install dependencies
+      - name: Setup NuGet
         uses: nuget/setup-nuget@v2
+      - name: Install dependencies
         run: nuget restore Source\NostalgicPlayer.sln
       - name: Build
         run: msbuild Source\NostalgicPlayer.sln -t:rebuild -property:configuration="Release" -property:Platform="Any CPU"

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -4,6 +4,7 @@ on: push
 jobs:
   Build_Release:
     runs-on: windows-latest
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -13,11 +13,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           lfs: 'true'
-      - name: Setup .NET Core SDK ${{ matrix.dotnet-version }}
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: ${{ matrix.dotnet-version }}
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v1
+      - name: Setup NuGet
+        uses: NuGet/setup-nuget@v1.0.2
       - name: Install dependencies
-        run: dotnet restore Source\NostalgicPlayer.sln
+        run: nuget restore Source\NostalgicPlayer.sln
       - name: Build
-        run: dotnet build Source\NostalgicPlayer.sln --configuration Release -p:Platform="Any CPU" --no-restore
+        run: msbuild Source\NostalgicPlayer.sln /nologo /nr:false /p:configuration="Release" /p:Platform="Any CPU"

--- a/.github/workflows/Test_Ancient.yml
+++ b/.github/workflows/Test_Ancient.yml
@@ -9,22 +9,19 @@ on:
 jobs:
   Test:
     runs-on: windows-latest
-    strategy:
-      matrix:
-        dotnet-version: [ '8.0.x' ]
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           lfs: 'true'
-      - name: Setup .NET Core SDK ${{ matrix.dotnet-version }}
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: ${{ matrix.dotnet-version }}
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v2
+      - name: Setup NuGet
+        uses: nuget/setup-nuget@v2
       - name: Install dependencies
-        run: dotnet restore Source\NostalgicPlayer.sln
+        run: nuget restore Source\NostalgicPlayer.sln
       - name: Build
-        run: dotnet build Source\NostalgicPlayer.sln --configuration Debug -p:Platform="Any CPU" --no-restore
+        run: msbuild Source\NostalgicPlayer.sln -t:rebuild -property:configuration="Debug" -property:Platform="Any CPU"
       - name: Test
         run: dotnet test Source\Ports\Tests\Ancient.Test\Ancient.Test.csproj --no-build --verbosity normal

--- a/.github/workflows/Test_LibFlac.yml
+++ b/.github/workflows/Test_LibFlac.yml
@@ -9,22 +9,19 @@ on:
 jobs:
   Test:
     runs-on: windows-latest
-    strategy:
-      matrix:
-        dotnet-version: [ '8.0.x' ]
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           lfs: 'true'
-      - name: Setup .NET Core SDK ${{ matrix.dotnet-version }}
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: ${{ matrix.dotnet-version }}
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v2
+      - name: Setup NuGet
+        uses: nuget/setup-nuget@v2
       - name: Install dependencies
-        run: dotnet restore Source\NostalgicPlayer.sln
+        run: nuget restore Source\NostalgicPlayer.sln
       - name: Build
-        run: dotnet build Source\NostalgicPlayer.sln --configuration Debug -p:Platform="Any CPU" --no-restore
+        run: msbuild Source\NostalgicPlayer.sln -t:rebuild -property:configuration="Debug" -property:Platform="Any CPU"
       - name: Test
         run: dotnet test Source\Ports\Tests\LibFlac.Test\LibFlac.Test.csproj --no-build --verbosity normal

--- a/.github/workflows/Test_LibSidPlayFp.yml
+++ b/.github/workflows/Test_LibSidPlayFp.yml
@@ -9,9 +9,6 @@ on:
 jobs:
   Test:
     runs-on: windows-latest
-    strategy:
-      matrix:
-        dotnet-version: [ '8.0.x' ]
 
     steps:
       - name: Checkout
@@ -24,13 +21,13 @@ jobs:
           repository: libsidplayfp/VICE-testprogs
           lfs: 'true'
           path: ./Source/Ports/Tests/LibSidPlayFp.Test/Vice/VICE-testprogs
-      - name: Setup .NET Core SDK ${{ matrix.dotnet-version }}
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: ${{ matrix.dotnet-version }}
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v2
+      - name: Setup NuGet
+        uses: nuget/setup-nuget@v2
       - name: Install dependencies
-        run: dotnet restore Source\NostalgicPlayer.sln
+        run: nuget restore Source\NostalgicPlayer.sln
       - name: Build
-        run: dotnet build Source\NostalgicPlayer.sln --configuration Debug -p:Platform="Any CPU" --no-restore
+        run: msbuild Source\NostalgicPlayer.sln -t:rebuild -property:configuration="Debug" -property:Platform="Any CPU"
       - name: Test
         run: dotnet test Source\Ports\Tests\LibSidPlayFp.Test\LibSidPlayFp.Test.csproj --no-build --verbosity normal

--- a/.github/workflows/Test_LibXmp.yml
+++ b/.github/workflows/Test_LibXmp.yml
@@ -9,22 +9,19 @@ on:
 jobs:
   Test:
     runs-on: windows-latest
-    strategy:
-      matrix:
-        dotnet-version: [ '8.0.x' ]
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           lfs: 'true'
-      - name: Setup .NET Core SDK ${{ matrix.dotnet-version }}
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: ${{ matrix.dotnet-version }}
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v2
+      - name: Setup NuGet
+        uses: nuget/setup-nuget@v2
       - name: Install dependencies
-        run: dotnet restore Source\NostalgicPlayer.sln
+        run: nuget restore Source\NostalgicPlayer.sln
       - name: Build
-        run: dotnet build Source\NostalgicPlayer.sln --configuration Debug -p:Platform="Any CPU" --no-restore
+        run: msbuild Source\NostalgicPlayer.sln -t:rebuild -property:configuration="Debug" -property:Platform="Any CPU"
       - name: Test
         run: dotnet test Source\Ports\Tests\LibXmp.Test\LibXmp.Test.csproj --no-build --verbosity normal


### PR DESCRIPTION
After the addition of a COM project to use the Shell component, the old GitHub actions did not work. This PR fixes the GitHub actions to work again.