### PR TITLE
Initial module list context menu support + Add the Rate context menu from Productivity Plus Pack if available on the local system

### DIFF
--- a/Source/Clients/NostalgicPlayer/Resources.Designer.cs
+++ b/Source/Clients/NostalgicPlayer/Resources.Designer.cs
@@ -952,6 +952,69 @@ namespace Polycode.NostalgicPlayer.Client.GuiPlayer {
                 return ResourceManager.GetString("IDS_CONTEXTMENU_LIST_SET_SUBSONG", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Properties.
+        /// </summary>
+        internal static string IDS_CONTEXTMENU_MODULELIST_PROPERTIES {
+            get {
+                return ResourceManager.GetString("IDS_CONTEXTMENU_MODULELIST_PROPERTIES", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Move down.
+        /// </summary>
+        internal static string IDS_CONTEXTMENU_MODULELIST_MOVE_DOWN {
+            get {
+                return ResourceManager.GetString("IDS_CONTEXTMENU_MODULELIST_MOVE_DOWN", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Move up.
+        /// </summary>
+        internal static string IDS_CONTEXTMENU_MODULELIST_MOVE_UP {
+            get {
+                return ResourceManager.GetString("IDS_CONTEXTMENU_MODULELIST_MOVE_UP", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Load/save.
+        /// </summary>
+        internal static string IDS_CONTEXTMENU_MODULELIST_LOAD_SAVE {
+            get {
+                return ResourceManager.GetString("IDS_CONTEXTMENU_MODULELIST_LOAD_SAVE", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Other actions.
+        /// </summary>
+        internal static string IDS_CONTEXTMENU_MODULELIST_OTHER_ACTIONS {
+            get {
+                return ResourceManager.GetString("IDS_CONTEXTMENU_MODULELIST_OTHER_ACTIONS", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Show in File Explorer.
+        /// </summary>
+        internal static string IDS_CONTEXTMENU_MODULELIST_SHOW_IN_FILE_EXPLORER {
+            get {
+                return ResourceManager.GetString("IDS_CONTEXTMENU_MODULELIST_SHOW_IN_FILE_EXPLORER", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Sort.
+        /// </summary>
+        internal static string IDS_CONTEXTMENU_MODULELIST_SORT {
+            get {
+                return ResourceManager.GetString("IDS_CONTEXTMENU_MODULELIST_SORT", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Shuffle.

--- a/Source/Clients/NostalgicPlayer/Resources.resx
+++ b/Source/Clients/NostalgicPlayer/Resources.resx
@@ -504,6 +504,27 @@ Formats supported:
   <data name="IDS_CONTEXTMENU_LIST_SET_SUBSONG" xml:space="preserve">
     <value>Set current sub-song as default</value>
   </data>
+  <data name="IDS_CONTEXTMENU_MODULELIST_PROPERTIES" xml:space="preserve">
+    <value>Properties</value>
+  </data>
+  <data name="IDS_CONTEXTMENU_MODULELIST_MOVE_DOWN" xml:space="preserve">
+    <value>Move down</value>
+  </data>
+  <data name="IDS_CONTEXTMENU_MODULELIST_MOVE_UP" xml:space="preserve">
+    <value>Move up</value>
+  </data>
+  <data name="IDS_CONTEXTMENU_MODULELIST_LOAD_SAVE" xml:space="preserve">
+    <value>Load/save</value>
+  </data>
+  <data name="IDS_CONTEXTMENU_MODULELIST_OTHER_ACTIONS" xml:space="preserve">
+    <value>Other actions</value>
+  </data>
+  <data name="IDS_CONTEXTMENU_MODULELIST_SHOW_IN_FILE_EXPLORER" xml:space="preserve">
+    <value>Show in File Explorer</value>
+  </data>
+  <data name="IDS_CONTEXTMENU_MODULELIST_SORT" xml:space="preserve">
+    <value>Sort</value>
+  </data>
   <data name="IDS_CONTEXTMENU_SORT_SHUFFLE" xml:space="preserve">
     <value>Shuffle</value>
   </data>

--- a/Source/Clients/NostalgicPlayer/Windows/ExplorerCommandMenu.cs
+++ b/Source/Clients/NostalgicPlayer/Windows/ExplorerCommandMenu.cs
@@ -1,0 +1,601 @@
+/******************************************************************************/
+/* This source, or parts thereof, may be used in any software as long the     */
+/* license of NostalgicPlayer is keep. See the LICENSE file for more          */
+/* information.                                                               */
+/******************************************************************************/
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.ComTypes;
+
+namespace Polycode.NostalgicPlayer.Client.GuiPlayer.Windows
+{
+	/// <summary>
+	/// COM service provider exposed to hosted Explorer commands
+	/// </summary>
+	[ComVisible(true)]
+	[Guid("6D5140C1-7436-11CE-8034-00AA006009FA")]
+	[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+	public interface IExplorerCommandSiteServiceProvider
+	{
+		/// <summary>
+		/// Return a service exposed by the command host
+		/// </summary>
+		[PreserveSig]
+		int QueryService(ref Guid service, ref Guid interfaceId, out IntPtr result);
+	}
+
+	/// <summary>
+	/// Window handle exposed to hosted Explorer commands
+	/// </summary>
+	[ComVisible(true)]
+	[Guid("00000114-0000-0000-C000-000000000046")]
+	[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+	public interface IExplorerCommandSiteOleWindow
+	{
+		/// <summary>
+		/// Return the host window handle
+		/// </summary>
+		[PreserveSig]
+		int GetWindow(out IntPtr windowHandle);
+
+		/// <summary>
+		/// Enter or leave context-sensitive help mode
+		/// </summary>
+		[PreserveSig]
+		int ContextSensitiveHelp([MarshalAs(UnmanagedType.Bool)] bool enterMode);
+	}
+
+	/// <summary>
+	/// UI mode service exposed to hosted Explorer commands
+	/// </summary>
+	[ComVisible(true)]
+	[Guid("4B6832A2-5F04-4C9D-B89D-727A15D103E7")]
+	[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+	public interface IExplorerCommandSiteExecuteCommandHost
+	{
+		/// <summary>
+		/// Return the host UI mode
+		/// </summary>
+		[PreserveSig]
+		int GetUiMode(out int uiMode);
+	}
+
+	/// <summary>
+	/// Hosts an IExplorerCommand and exposes its menu hierarchy
+	/// </summary>
+	internal sealed class ExplorerCommandMenu : IDisposable
+	{
+		private const int ClassNotRegistered = unchecked((int)0x80040154);
+
+		private readonly IShellItemArray shellItems;
+		private readonly ExplorerCommandSite site;
+		private readonly List<IExplorerCommand> commands;
+		private readonly List<Entry> entries;
+
+		private bool disposed;
+
+		/********************************************************************/
+		/// <summary>
+		/// A single command in the Explorer command hierarchy
+		/// </summary>
+		/********************************************************************/
+		internal sealed class Entry
+		{
+			private readonly ExplorerCommandMenu owner;
+			private readonly IExplorerCommand command;
+			private Image image;
+
+			public string Text { get; }
+			public string ToolTipText { get; }
+			public bool Enabled { get; }
+			public bool Visible { get; }
+			public bool Checked { get; }
+			public bool IsSeparator { get; }
+			public bool SeparatorBefore { get; }
+			public bool SeparatorAfter { get; }
+			public IReadOnlyList<Entry> Children { get; }
+
+			/****************************************************************/
+			/// <summary>
+			/// Constructor
+			/// </summary>
+			/****************************************************************/
+			internal Entry(ExplorerCommandMenu owner, IExplorerCommand command, string text, string toolTipText, Image image, ExplorerCommandState state, ExplorerCommandFlags flags, IReadOnlyList<Entry> children)
+			{
+				this.owner = owner;
+				this.command = command;
+
+				Text = text;
+				ToolTipText = toolTipText;
+				this.image = image;
+				Enabled = (state & ExplorerCommandState.Disabled) == 0;
+				Visible = (state & ExplorerCommandState.Hidden) == 0;
+				Checked = (state & ExplorerCommandState.Checked) != 0;
+				IsSeparator = (flags & ExplorerCommandFlags.IsSeparator) != 0;
+				SeparatorBefore = (flags & ExplorerCommandFlags.SeparatorBefore) != 0;
+				SeparatorAfter = (flags & ExplorerCommandFlags.SeparatorAfter) != 0;
+				Children = children;
+			}
+
+
+
+			/****************************************************************/
+			/// <summary>
+			/// Transfer ownership of the command image to the menu item
+			/// </summary>
+			/****************************************************************/
+			public Image TakeImage()
+			{
+				Image result = image;
+				image = null;
+				return result;
+			}
+
+
+
+			/****************************************************************/
+			/// <summary>
+			/// Invoke the command for the selected files
+			/// </summary>
+			/****************************************************************/
+			public void Invoke()
+			{
+				owner.ThrowIfDisposed();
+				Marshal.ThrowExceptionForHR(command.Invoke(owner.shellItems, null));
+			}
+
+
+
+			/****************************************************************/
+			/// <summary>
+			/// Dispose images that have not been transferred to menu items
+			/// </summary>
+			/****************************************************************/
+			internal void DisposeImage()
+			{
+				image?.Dispose();
+				image = null;
+			}
+		}
+
+		public Entry Root { get; }
+
+		/********************************************************************/
+		/// <summary>
+		/// Constructor
+		/// </summary>
+		/********************************************************************/
+		private ExplorerCommandMenu(Guid classId, IntPtr ownerWindow, IReadOnlyList<string> fileNames)
+		{
+			commands = new List<IExplorerCommand>();
+			entries = new List<Entry>();
+			site = new ExplorerCommandSite(ownerWindow);
+			shellItems = null;
+
+			try
+			{
+				shellItems = CreateShellItemArray(fileNames);
+
+				Type commandType = Type.GetTypeFromCLSID(classId, true);
+				object commandObject = Activator.CreateInstance(commandType);
+				IExplorerCommand command = commandObject as IExplorerCommand ?? throw new InvalidCastException();
+
+				Root = CreateEntry(command);
+			}
+			catch
+			{
+				ReleaseResources();
+				throw;
+			}
+		}
+
+
+
+		/********************************************************************/
+		/// <summary>
+		/// Try to create the command menu. Null means that the COM package is
+		/// not installed
+		/// </summary>
+		/********************************************************************/
+		public static ExplorerCommandMenu TryCreate(Guid classId, IntPtr ownerWindow, IReadOnlyList<string> fileNames)
+		{
+			try
+			{
+				return new ExplorerCommandMenu(classId, ownerWindow, fileNames);
+			}
+			catch (COMException ex) when (ex.HResult == ClassNotRegistered)
+			{
+				return null;
+			}
+		}
+
+
+
+		/********************************************************************/
+		/// <summary>
+		/// Release all hosted COM objects
+		/// </summary>
+		/********************************************************************/
+		public void Dispose()
+		{
+			if (disposed)
+				return;
+
+			disposed = true;
+			ReleaseResources();
+		}
+
+
+
+		/********************************************************************/
+		/// <summary>
+		/// Release images and COM objects created by the command hierarchy
+		/// </summary>
+		/********************************************************************/
+		private void ReleaseResources()
+		{
+			foreach (Entry entry in entries)
+				entry.DisposeImage();
+
+			for (int i = commands.Count - 1; i >= 0; i--)
+			{
+				IExplorerCommand command = commands[i];
+
+				try
+				{
+					if (command is IObjectWithSite objectWithSite)
+						objectWithSite.SetSite(null);
+				}
+				catch (COMException)
+				{
+				}
+
+				Marshal.ReleaseComObject(command);
+			}
+
+			commands.Clear();
+
+			if (shellItems != null)
+				Marshal.ReleaseComObject(shellItems);
+		}
+
+
+
+		/********************************************************************/
+		/// <summary>
+		/// Create a menu entry from an Explorer command
+		/// </summary>
+		/********************************************************************/
+		private Entry CreateEntry(IExplorerCommand command)
+		{
+			commands.Add(command);
+			Image image = null;
+
+			try
+			{
+				if (command is IObjectWithSite objectWithSite)
+					Marshal.ThrowExceptionForHR(objectWithSite.SetSite(site));
+
+				string text = GetCommandString((out IntPtr value) => command.GetTitle(shellItems, out value));
+				string toolTipText = GetCommandString((out IntPtr value) => command.GetToolTip(shellItems, out value));
+				image = GetCommandImage(GetCommandString((out IntPtr value) => command.GetIcon(shellItems, out value)));
+
+				Marshal.ThrowExceptionForHR(command.GetState(shellItems, true, out ExplorerCommandState state));
+
+				ExplorerCommandFlags flags = ExplorerCommandFlags.Default;
+				int result = command.GetFlags(out flags);
+				if (result < 0)
+					flags = ExplorerCommandFlags.Default;
+
+				List<Entry> children = new List<Entry>();
+				if ((flags & ExplorerCommandFlags.HasSubCommands) != 0)
+					AddSubCommands(command, children);
+
+				Entry entry = new Entry(this, command, text, toolTipText, image, state, flags, children);
+				entries.Add(entry);
+				return entry;
+			}
+			catch
+			{
+				image?.Dispose();
+				throw;
+			}
+		}
+
+
+
+		/********************************************************************/
+		/// <summary>
+		/// Add all subcommands exposed by the given command
+		/// </summary>
+		/********************************************************************/
+		private void AddSubCommands(IExplorerCommand command, List<Entry> entries)
+		{
+			int result = command.EnumSubCommands(out IEnumExplorerCommand enumerator);
+			if ((result < 0) || (enumerator == null))
+				return;
+
+			try
+			{
+				for (;;)
+				{
+					result = enumerator.Next(1, out IExplorerCommand childCommand, out uint fetched);
+					if ((result != 0) || (fetched == 0))
+						break;
+
+					entries.Add(CreateEntry(childCommand));
+				}
+			}
+			finally
+			{
+				Marshal.ReleaseComObject(enumerator);
+			}
+		}
+
+
+
+		/********************************************************************/
+		/// <summary>
+		/// Retrieve a string allocated by an Explorer command
+		/// </summary>
+		/********************************************************************/
+		private static string GetCommandString(GetExplorerCommandString getter)
+		{
+			IntPtr valuePointer = IntPtr.Zero;
+
+			try
+			{
+				int result = getter(out valuePointer);
+				return (result >= 0) && (valuePointer != IntPtr.Zero) ? Marshal.PtrToStringUni(valuePointer) : null;
+			}
+			finally
+			{
+				if (valuePointer != IntPtr.Zero)
+					Marshal.FreeCoTaskMem(valuePointer);
+			}
+		}
+
+
+
+		/********************************************************************/
+		/// <summary>
+		/// Create a shell item array containing all selected physical files
+		/// </summary>
+		/********************************************************************/
+		private static IShellItemArray CreateShellItemArray(IReadOnlyList<string> fileNames)
+		{
+			IntPtr[] itemIdLists = new IntPtr[fileNames.Count];
+
+			try
+			{
+				for (int i = 0; i < fileNames.Count; i++)
+				{
+					Marshal.ThrowExceptionForHR(SHParseDisplayName(fileNames[i], null, out itemIdLists[i], 0, out _));
+				}
+
+				Marshal.ThrowExceptionForHR(SHCreateShellItemArrayFromIDLists((uint)itemIdLists.Length, itemIdLists, out IShellItemArray shellItems));
+				return shellItems;
+			}
+			finally
+			{
+				foreach (IntPtr itemIdList in itemIdLists)
+				{
+					if (itemIdList != IntPtr.Zero)
+						Marshal.FreeCoTaskMem(itemIdList);
+				}
+			}
+		}
+
+
+
+		/********************************************************************/
+		/// <summary>
+		/// Load the icon returned by IExplorerCommand
+		/// </summary>
+		/********************************************************************/
+		private static Image GetCommandImage(string iconLocation)
+		{
+			if (string.IsNullOrEmpty(iconLocation))
+				return null;
+
+			int iconIndex = 0;
+			int commaIndex = iconLocation.LastIndexOf(',');
+
+			if ((commaIndex >= 0) && int.TryParse(iconLocation.AsSpan(commaIndex + 1).Trim(), out int parsedIndex))
+			{
+				iconIndex = parsedIndex;
+				iconLocation = iconLocation.Substring(0, commaIndex);
+			}
+
+			string iconFileName = Environment.ExpandEnvironmentVariables(iconLocation.Trim().Trim('"').TrimStart('@'));
+			if (!File.Exists(iconFileName))
+				return null;
+
+			IntPtr[] smallIcons = new IntPtr[1];
+			if (ExtractIconEx(iconFileName, iconIndex, null, smallIcons, 1) == 0)
+				return null;
+
+			try
+			{
+				using (Icon icon = (Icon)Icon.FromHandle(smallIcons[0]).Clone())
+					return icon.ToBitmap();
+			}
+			finally
+			{
+				DestroyIcon(smallIcons[0]);
+			}
+		}
+
+
+
+		/********************************************************************/
+		/// <summary>
+		/// Throw if the hosted command has already been released
+		/// </summary>
+		/********************************************************************/
+		private void ThrowIfDisposed()
+		{
+			ObjectDisposedException.ThrowIf(disposed, this);
+		}
+
+		private delegate int GetExplorerCommandString(out IntPtr value);
+
+		[Flags]
+		internal enum ExplorerCommandState : uint
+		{
+			Enabled = 0,
+			Disabled = 0x1,
+			Hidden = 0x2,
+			CheckBox = 0x4,
+			Checked = 0x8,
+			RadioCheck = 0x10
+		}
+
+		[Flags]
+		internal enum ExplorerCommandFlags : uint
+		{
+			Default = 0,
+			HasSubCommands = 0x1,
+			HasSplitButton = 0x2,
+			HideLabel = 0x4,
+			IsSeparator = 0x8,
+			HasLuaShield = 0x10,
+			SeparatorBefore = 0x20,
+			SeparatorAfter = 0x40,
+			IsDropDown = 0x80,
+			Toggleable = 0x100,
+			AutoMenuIcons = 0x200
+		}
+
+		[ComImport]
+		[Guid("A08CE4D0-FA25-44AB-B57C-C7B1C323E0B9")]
+		[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+		internal interface IExplorerCommand
+		{
+			[PreserveSig]
+			int GetTitle(IShellItemArray shellItems, out IntPtr name);
+
+			[PreserveSig]
+			int GetIcon(IShellItemArray shellItems, out IntPtr icon);
+
+			[PreserveSig]
+			int GetToolTip(IShellItemArray shellItems, out IntPtr toolTip);
+
+			[PreserveSig]
+			int GetCanonicalName(out Guid commandName);
+
+			[PreserveSig]
+			int GetState(IShellItemArray shellItems, [MarshalAs(UnmanagedType.Bool)] bool allowSlowOperation, out ExplorerCommandState commandState);
+
+			[PreserveSig]
+			int Invoke(IShellItemArray shellItems, IBindCtx bindContext);
+
+			[PreserveSig]
+			int GetFlags(out ExplorerCommandFlags flags);
+
+			[PreserveSig]
+			int EnumSubCommands(out IEnumExplorerCommand enumerator);
+		}
+
+		[ComImport]
+		[Guid("A88826F8-186F-4987-AADE-EA0CEF8FBFE8")]
+		[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+		internal interface IEnumExplorerCommand
+		{
+			[PreserveSig]
+			int Next(uint count, out IExplorerCommand command, out uint fetched);
+
+			[PreserveSig]
+			int Skip(uint count);
+
+			[PreserveSig]
+			int Reset();
+
+			[PreserveSig]
+			int Clone(out IEnumExplorerCommand enumerator);
+		}
+
+		[ComImport]
+		[Guid("FC4801A3-2BA9-11CF-A229-00AA003D7352")]
+		[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+		private interface IObjectWithSite
+		{
+			[PreserveSig]
+			int SetSite([MarshalAs(UnmanagedType.IUnknown)] object site);
+
+			[PreserveSig]
+			int GetSite(ref Guid interfaceId, out IntPtr site);
+		}
+
+		[ComImport]
+		[Guid("B63EA76D-1F85-456F-A19C-48159EFA858B")]
+		[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+		internal interface IShellItemArray
+		{
+		}
+
+		[ComVisible(true)]
+		[ClassInterface(ClassInterfaceType.None)]
+		private sealed class ExplorerCommandSite : IExplorerCommandSiteServiceProvider, IExplorerCommandSiteOleWindow, IExplorerCommandSiteExecuteCommandHost
+		{
+			private const int NoInterface = unchecked((int)0x80004002);
+
+			private static readonly Guid OleWindowInterfaceId = new Guid("00000114-0000-0000-C000-000000000046");
+			private static readonly Guid ExecuteCommandHostInterfaceId = new Guid("4B6832A2-5F04-4C9D-B89D-727A15D103E7");
+
+			private readonly IntPtr windowHandle;
+
+			public ExplorerCommandSite(IntPtr windowHandle)
+			{
+				this.windowHandle = windowHandle;
+			}
+
+			public int QueryService(ref Guid service, ref Guid interfaceId, out IntPtr result)
+			{
+				result = IntPtr.Zero;
+
+				if ((service == ExecuteCommandHostInterfaceId) && (interfaceId == ExecuteCommandHostInterfaceId))
+					result = Marshal.GetComInterfaceForObject(this, typeof(IExplorerCommandSiteExecuteCommandHost));
+				else if (interfaceId == OleWindowInterfaceId)
+					result = Marshal.GetComInterfaceForObject(this, typeof(IExplorerCommandSiteOleWindow));
+				else
+					return NoInterface;
+
+				return 0;
+			}
+
+			public int GetWindow(out IntPtr windowHandle)
+			{
+				windowHandle = this.windowHandle;
+				return 0;
+			}
+
+			public int ContextSensitiveHelp(bool enterMode)
+			{
+				return unchecked((int)0x80004001);
+			}
+
+			public int GetUiMode(out int uiMode)
+			{
+				uiMode = 0;
+				return 0;
+			}
+		}
+
+		[DllImport("shell32.dll", CharSet = CharSet.Unicode, PreserveSig = true)]
+		private static extern int SHParseDisplayName(string name, IBindCtx bindContext, out IntPtr itemIdList, uint attributes, out uint attributesOut);
+
+		[DllImport("shell32.dll", PreserveSig = true)]
+		private static extern int SHCreateShellItemArrayFromIDLists(uint count, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 0)] IntPtr[] itemIdLists, out IShellItemArray shellItems);
+
+		[DllImport("shell32.dll", CharSet = CharSet.Unicode)]
+		private static extern uint ExtractIconEx(string fileName, int iconIndex, IntPtr[] largeIcons, IntPtr[] smallIcons, uint iconCount);
+
+		[DllImport("user32.dll")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		private static extern bool DestroyIcon(IntPtr iconHandle);
+	}
+}

--- a/Source/Clients/NostalgicPlayer/Windows/ExplorerCommandToolStripMenu.cs
+++ b/Source/Clients/NostalgicPlayer/Windows/ExplorerCommandToolStripMenu.cs
@@ -1,0 +1,228 @@
+/******************************************************************************/
+/* This source, or parts thereof, may be used in any software as long the     */
+/* license of NostalgicPlayer is keep. See the LICENSE file for more          */
+/* information.                                                               */
+/******************************************************************************/
+using System;
+using System.Collections.Generic;
+using System.Windows.Forms;
+using Polycode.NostalgicPlayer.Controls.Menus;
+
+namespace Polycode.NostalgicPlayer.Client.GuiPlayer.Windows
+{
+	/// <summary>
+	/// Defines an Explorer command and how its top-level menu item is shown
+	/// </summary>
+	internal readonly struct ExplorerCommandDefinition
+	{
+		public Guid ClassId { get; }
+		public bool RenderTopLevelIcon { get; }
+
+		/********************************************************************/
+		/// <summary>
+		/// Constructor
+		/// </summary>
+		/********************************************************************/
+		public ExplorerCommandDefinition(Guid classId, bool renderTopLevelIcon)
+		{
+			ClassId = classId;
+			RenderTopLevelIcon = renderTopLevelIcon;
+		}
+	}
+
+	/// <summary>
+	/// Renders and invokes an Explorer command in a ToolStrip menu
+	/// </summary>
+	internal sealed class ExplorerCommandToolStripMenu : IDisposable
+	{
+		private readonly ExplorerCommandDefinition definition;
+		private readonly Action<Exception> invocationErrorHandler;
+
+		private ExplorerCommandMenu explorerCommandMenu;
+
+		public NostalgicToolStripMenuItem MenuItem { get; }
+
+		/********************************************************************/
+		/// <summary>
+		/// Constructor
+		/// </summary>
+		/********************************************************************/
+		public ExplorerCommandToolStripMenu(ExplorerCommandDefinition definition, Action<Exception> invocationErrorHandler)
+		{
+			this.definition = definition;
+			this.invocationErrorHandler = invocationErrorHandler;
+
+			MenuItem = new NostalgicToolStripMenuItem
+			{
+				Visible = false
+			};
+
+			MenuItem.Click += MenuItem_Click;
+		}
+
+
+
+		/********************************************************************/
+		/// <summary>
+		/// Rebuild the menu for the given selected files
+		/// </summary>
+		/********************************************************************/
+		public void Update(IntPtr ownerWindow, IReadOnlyList<string> fileNames)
+		{
+			Clear();
+
+			try
+			{
+				explorerCommandMenu = ExplorerCommandMenu.TryCreate(definition.ClassId, ownerWindow, fileNames);
+				ExplorerCommandMenu.Entry root = explorerCommandMenu?.Root;
+
+				if ((root == null) || !root.Visible || string.IsNullOrEmpty(root.Text))
+				{
+					Clear();
+					return;
+				}
+
+				MenuItem.Text = root.Text;
+				MenuItem.ToolTipText = root.ToolTipText;
+				MenuItem.Enabled = root.Enabled;
+				MenuItem.Checked = root.Checked;
+
+				if (definition.RenderTopLevelIcon)
+					MenuItem.Image = root.TakeImage();
+
+				AddMenuItems(MenuItem.DropDownItems, root.Children);
+				MenuItem.Visible = true;
+			}
+			catch
+			{
+				Clear();
+			}
+		}
+
+
+
+		/********************************************************************/
+		/// <summary>
+		/// Hide the menu and release the current Explorer command
+		/// </summary>
+		/********************************************************************/
+		public void Clear()
+		{
+			MenuItem.Visible = false;
+
+			while (MenuItem.DropDownItems.Count > 0)
+			{
+				ToolStripItem item = MenuItem.DropDownItems[0];
+				MenuItem.DropDownItems.RemoveAt(0);
+				item.Dispose();
+			}
+
+			MenuItem.Image?.Dispose();
+			MenuItem.Image = null;
+
+			explorerCommandMenu?.Dispose();
+			explorerCommandMenu = null;
+		}
+
+
+
+		/********************************************************************/
+		/// <summary>
+		/// Release the menu and current Explorer command
+		/// </summary>
+		/********************************************************************/
+		public void Dispose()
+		{
+			Clear();
+			MenuItem.Dispose();
+		}
+
+
+
+		/********************************************************************/
+		/// <summary>
+		/// Invoke a top-level command that has no subcommands
+		/// </summary>
+		/********************************************************************/
+		private void MenuItem_Click(object sender, EventArgs e)
+		{
+			ExplorerCommandMenu.Entry root = explorerCommandMenu?.Root;
+			if ((root != null) && (root.Children.Count == 0))
+				Invoke(root);
+		}
+
+
+
+		/********************************************************************/
+		/// <summary>
+		/// Add Explorer command entries to a ToolStrip menu
+		/// </summary>
+		/********************************************************************/
+		private void AddMenuItems(ToolStripItemCollection menuItems, IReadOnlyList<ExplorerCommandMenu.Entry> commands)
+		{
+			foreach (ExplorerCommandMenu.Entry command in commands)
+			{
+				if (!command.Visible)
+					continue;
+
+				if (command.SeparatorBefore)
+					AddSeparator(menuItems);
+
+				if (command.IsSeparator)
+					AddSeparator(menuItems);
+				else
+				{
+					NostalgicToolStripMenuItem menuItem = new NostalgicToolStripMenuItem(command.Text)
+					{
+						ToolTipText = command.ToolTipText,
+						Image = command.TakeImage(),
+						Enabled = command.Enabled,
+						Checked = command.Checked
+					};
+
+					if (command.Children.Count > 0)
+						AddMenuItems(menuItem.DropDownItems, command.Children);
+					else
+						menuItem.Click += (sender, e) => Invoke(command);
+
+					menuItems.Add(menuItem);
+				}
+
+				if (command.SeparatorAfter)
+					AddSeparator(menuItems);
+			}
+		}
+
+
+
+		/********************************************************************/
+		/// <summary>
+		/// Add a separator unless the menu already ends with one
+		/// </summary>
+		/********************************************************************/
+		private static void AddSeparator(ToolStripItemCollection menuItems)
+		{
+			if ((menuItems.Count > 0) && (menuItems[menuItems.Count - 1] is not ToolStripSeparator))
+				menuItems.Add(new ToolStripSeparator());
+		}
+
+
+
+		/********************************************************************/
+		/// <summary>
+		/// Invoke an Explorer command and report any error
+		/// </summary>
+		/********************************************************************/
+		private void Invoke(ExplorerCommandMenu.Entry command)
+		{
+			try
+			{
+				command.Invoke();
+			}
+			catch (Exception ex)
+			{
+				invocationErrorHandler?.Invoke(ex);
+			}
+		}
+	}
+}

--- a/Source/Clients/NostalgicPlayer/Windows/MainWindow/MainWindowForm.Designer.cs
+++ b/Source/Clients/NostalgicPlayer/Windows/MainWindow/MainWindowForm.Designer.cs
@@ -74,6 +74,7 @@ namespace Polycode.NostalgicPlayer.Client.GuiPlayer.Windows.MainWindow
 			neverEndingTimer = new System.Windows.Forms.Timer(components);
 			addContextMenu = new Polycode.NostalgicPlayer.Controls.Menus.NostalgicContextMenu(components);
 			moduleList = new Polycode.NostalgicPlayer.Controls.Lists.NostalgicModuleList();
+			moduleListContextMenu = new Polycode.NostalgicPlayer.Controls.Menus.NostalgicContextMenu(components);
 			searchPopupControl = new SearchPopupControl();
 			infoBox.SuspendLayout();
 			listButtonsBox.SuspendLayout();
@@ -441,6 +442,11 @@ namespace Polycode.NostalgicPlayer.Client.GuiPlayer.Windows.MainWindow
 			addContextMenu.ImageArea = NostalgicPlayer.Controls.Types.ImageBankArea.Main;
 			addContextMenu.Name = "addContextMenu";
 			// 
+			// moduleListContextMenu
+			// 
+			moduleListContextMenu.ImageArea = NostalgicPlayer.Controls.Types.ImageBankArea.Main;
+			moduleListContextMenu.Name = "moduleListContextMenu";
+			// 
 			// moduleList
 			// 
 			moduleList.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
@@ -532,6 +538,7 @@ namespace Polycode.NostalgicPlayer.Client.GuiPlayer.Windows.MainWindow
 		private NostalgicPlayer.Controls.Lists.NostalgicModuleList moduleList;
 		private SearchPopupControl searchPopupControl;
 		private NostalgicPlayer.Controls.Components.FontConfiguration bigFontConfiguration;
+		private NostalgicPlayer.Controls.Menus.NostalgicContextMenu moduleListContextMenu;
 	}
 }
 

--- a/Source/Clients/NostalgicPlayer/Windows/MainWindow/MainWindowForm.cs
+++ b/Source/Clients/NostalgicPlayer/Windows/MainWindow/MainWindowForm.cs
@@ -2000,18 +2000,18 @@ namespace Polycode.NostalgicPlayer.Client.GuiPlayer.Windows.MainWindow
 			moduleListSetSubSongMenuItem.Enabled = moduleHandler.IsModuleLoaded;
 			moduleListClearSubSongMenuItem.Enabled = hasSelection && moduleList.SelectedItems.Any(x => x.DefaultSubSong.HasValue);
 
-			// Hide unsupported Windows shell actions when running on Windows 10 S
-			bool fileActionsVisible = !Env.IsWindows10S;
-			fileActionsSeparatorMenuItem.Visible = fileActionsVisible;
-			showInFileExplorerMenuItem.Visible = fileActionsVisible;
-			propertiesMenuItem.Visible = fileActionsVisible;
+			// Determine whether Windows shell actions were created for this system
+			bool fileActionsVisible = fileActionsSeparatorMenuItem != null;
 
 			// Enable file actions only for an existing local file selected from an item
-			string fileName = GetPhysicalFilePath(moduleListContextItem?.ListItem);
+			string fileName = fileActionsVisible ? GetPhysicalFilePath(moduleListContextItem?.ListItem) : null;
 			bool fileActionAvailable = hasSelection && fileActionsVisible && !string.IsNullOrEmpty(fileName) && File.Exists(fileName);
 
-			showInFileExplorerMenuItem.Enabled = fileActionAvailable;
-			propertiesMenuItem.Enabled = fileActionAvailable;
+			if (fileActionsVisible)
+			{
+				showInFileExplorerMenuItem.Enabled = fileActionAvailable;
+				propertiesMenuItem.Enabled = fileActionAvailable;
+			}
 
 			// Build optional Explorer commands for the selected physical files
 			UpdateModuleListExplorerCommandMenus(hasSelection, fileActionsVisible);
@@ -3719,27 +3719,27 @@ namespace Polycode.NostalgicPlayer.Client.GuiPlayer.Windows.MainWindow
 			loadSaveSubMenu.DropDownItems.Add(loadSaveItem);
 
 
-			// File actions
-			fileActionsSeparatorMenuItem = new ToolStripSeparator();
-			moduleListContextMenu.Items.Add(fileActionsSeparatorMenuItem);
-
 			if (!Env.IsWindows10S)
 			{
+				// File actions
+				fileActionsSeparatorMenuItem = new ToolStripSeparator();
+				moduleListContextMenu.Items.Add(fileActionsSeparatorMenuItem);
+
 				foreach (ExplorerCommandDefinition definition in ModuleListExplorerCommandDefinitions)
 				{
 					ExplorerCommandToolStripMenu commandMenu = new ExplorerCommandToolStripMenu(definition, ex => ShowSimpleErrorMessage(ex.Message));
 					moduleListExplorerCommandMenus.Add(commandMenu);
 					moduleListContextMenu.Items.Add(commandMenu.MenuItem);
 				}
+
+				showInFileExplorerMenuItem = new NostalgicToolStripMenuItem(Resources.IDS_CONTEXTMENU_MODULELIST_SHOW_IN_FILE_EXPLORER);
+				showInFileExplorerMenuItem.Click += ModuleListMenu_ShowInFileExplorer;
+				moduleListContextMenu.Items.Add(showInFileExplorerMenuItem);
+
+				propertiesMenuItem = new NostalgicToolStripMenuItem(Resources.IDS_CONTEXTMENU_MODULELIST_PROPERTIES);
+				propertiesMenuItem.Click += ModuleListMenu_Properties;
+				moduleListContextMenu.Items.Add(propertiesMenuItem);
 			}
-
-			showInFileExplorerMenuItem = new NostalgicToolStripMenuItem(Resources.IDS_CONTEXTMENU_MODULELIST_SHOW_IN_FILE_EXPLORER);
-			showInFileExplorerMenuItem.Click += ModuleListMenu_ShowInFileExplorer;
-			moduleListContextMenu.Items.Add(showInFileExplorerMenuItem);
-
-			propertiesMenuItem = new NostalgicToolStripMenuItem(Resources.IDS_CONTEXTMENU_MODULELIST_PROPERTIES);
-			propertiesMenuItem.Click += ModuleListMenu_Properties;
-			moduleListContextMenu.Items.Add(propertiesMenuItem);
 		}
 
 

--- a/Source/Clients/NostalgicPlayer/Windows/MainWindow/MainWindowForm.cs
+++ b/Source/Clients/NostalgicPlayer/Windows/MainWindow/MainWindowForm.cs
@@ -59,6 +59,11 @@ namespace Polycode.NostalgicPlayer.Client.GuiPlayer.Windows.MainWindow
 	/// </summary>
 	public partial class MainWindowForm : WindowFormBase2, IExtraChannels
 	{
+		private static readonly ExplorerCommandDefinition[] ModuleListExplorerCommandDefinitions =
+		[
+			new ExplorerCommandDefinition(new Guid("DF9672B2-B7C8-49F8-AE48-054B361C1448"), renderTopLevelIcon: false)
+		];
+
 		private class AgentEntry
 		{
 			public Guid TypeId { get; set; }
@@ -109,6 +114,7 @@ namespace Polycode.NostalgicPlayer.Client.GuiPlayer.Windows.MainWindow
 		private ToolStripSeparator fileActionsSeparatorMenuItem;
 		private NostalgicToolStripMenuItem showInFileExplorerMenuItem;
 		private NostalgicToolStripMenuItem propertiesMenuItem;
+		private readonly List<ExplorerCommandToolStripMenu> moduleListExplorerCommandMenus = new List<ExplorerCommandToolStripMenu>();
 		private ModuleListListItem moduleListContextItem;
 
 		// Timer variables
@@ -1459,6 +1465,8 @@ namespace Polycode.NostalgicPlayer.Client.GuiPlayer.Windows.MainWindow
 		{
 			using (new SleepCursor())
 			{
+				DisposeModuleListExplorerCommandMenus();
+
 				// Remember list/module properties
 				int rememberSelected, rememberPosition, rememberSong;
 
@@ -2004,6 +2012,9 @@ namespace Polycode.NostalgicPlayer.Client.GuiPlayer.Windows.MainWindow
 
 			showInFileExplorerMenuItem.Enabled = fileActionAvailable;
 			propertiesMenuItem.Enabled = fileActionAvailable;
+
+			// Build optional Explorer commands for the selected physical files
+			UpdateModuleListExplorerCommandMenus(hasSelection, fileActionsVisible);
 		}
 
 
@@ -2068,6 +2079,66 @@ namespace Polycode.NostalgicPlayer.Client.GuiPlayer.Windows.MainWindow
 				return ArchivePath.GetArchiveName(listItem.Source);
 
 			return null;
+		}
+
+
+
+		/********************************************************************/
+		/// <summary>
+		/// Rebuild all configured Explorer commands for the selected files
+		/// </summary>
+		/********************************************************************/
+		private void UpdateModuleListExplorerCommandMenus(bool hasSelection, bool fileActionsVisible)
+		{
+			if (moduleListExplorerCommandMenus.Count == 0)
+				return;
+
+			string[] fileNames = fileActionsVisible && hasSelection ? GetSelectedPhysicalFileNames() : null;
+			foreach (ExplorerCommandToolStripMenu commandMenu in moduleListExplorerCommandMenus)
+			{
+				if (fileNames != null)
+					commandMenu.Update(Handle, fileNames);
+				else
+					commandMenu.Clear();
+			}
+		}
+
+
+
+		/********************************************************************/
+		/// <summary>
+		/// Return all selected files, or null if an item is not a physical
+		/// non-archive file
+		/// </summary>
+		/********************************************************************/
+		private string[] GetSelectedPhysicalFileNames()
+		{
+			HashSet<string> fileNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+			foreach (ModuleListListItem selectedItem in moduleList.SelectedItems)
+			{
+				if ((selectedItem.ListItem is not SingleFileModuleListItem fileItem) || !File.Exists(fileItem.Source))
+					return null;
+
+				fileNames.Add(fileItem.Source);
+			}
+
+			return fileNames.Count > 0 ? fileNames.ToArray() : null;
+		}
+
+
+
+		/********************************************************************/
+		/// <summary>
+		/// Release all configured Explorer command menus
+		/// </summary>
+		/********************************************************************/
+		private void DisposeModuleListExplorerCommandMenus()
+		{
+			foreach (ExplorerCommandToolStripMenu commandMenu in moduleListExplorerCommandMenus)
+				commandMenu.Dispose();
+
+			moduleListExplorerCommandMenus.Clear();
 		}
 
 
@@ -3651,6 +3722,16 @@ namespace Polycode.NostalgicPlayer.Client.GuiPlayer.Windows.MainWindow
 			// File actions
 			fileActionsSeparatorMenuItem = new ToolStripSeparator();
 			moduleListContextMenu.Items.Add(fileActionsSeparatorMenuItem);
+
+			if (!Env.IsWindows10S)
+			{
+				foreach (ExplorerCommandDefinition definition in ModuleListExplorerCommandDefinitions)
+				{
+					ExplorerCommandToolStripMenu commandMenu = new ExplorerCommandToolStripMenu(definition, ex => ShowSimpleErrorMessage(ex.Message));
+					moduleListExplorerCommandMenus.Add(commandMenu);
+					moduleListContextMenu.Items.Add(commandMenu.MenuItem);
+				}
+			}
 
 			showInFileExplorerMenuItem = new NostalgicToolStripMenuItem(Resources.IDS_CONTEXTMENU_MODULELIST_SHOW_IN_FILE_EXPLORER);
 			showInFileExplorerMenuItem.Click += ModuleListMenu_ShowInFileExplorer;

--- a/Source/Clients/NostalgicPlayer/Windows/MainWindow/MainWindowForm.cs
+++ b/Source/Clients/NostalgicPlayer/Windows/MainWindow/MainWindowForm.cs
@@ -16,6 +16,7 @@ using Polycode.NostalgicPlayer.Client.GuiPlayer.Containers.Settings;
 using Polycode.NostalgicPlayer.Client.GuiPlayer.Factories;
 using Polycode.NostalgicPlayer.Client.GuiPlayer.Mappers;
 using Polycode.NostalgicPlayer.Client.GuiPlayer.Services;
+using Polycode.NostalgicPlayer.Client.GuiPlayer.Windows;
 using Polycode.NostalgicPlayer.Client.GuiPlayer.Windows.AboutWindow;
 using Polycode.NostalgicPlayer.Client.GuiPlayer.Windows.AgentWindow;
 using Polycode.NostalgicPlayer.Client.GuiPlayer.Windows.AudiusWindow;
@@ -39,6 +40,7 @@ using Polycode.NostalgicPlayer.Kit.Containers;
 using Polycode.NostalgicPlayer.Kit.Containers.Events;
 using Polycode.NostalgicPlayer.Kit.Containers.Flags;
 using Polycode.NostalgicPlayer.Kit.Containers.Types;
+using Polycode.NostalgicPlayer.Kit.Helpers;
 using Polycode.NostalgicPlayer.Kit.Interfaces;
 using Polycode.NostalgicPlayer.Kit.Utility;
 using Polycode.NostalgicPlayer.Kit.Utility.Interfaces;
@@ -98,6 +100,16 @@ namespace Polycode.NostalgicPlayer.Client.GuiPlayer.Windows.MainWindow
 		// Context menus
 		private NostalgicToolStripMenuItem setSubSongMenuItem;
 		private NostalgicToolStripMenuItem clearSubSongMenuItem;
+		private NostalgicToolStripMenuItem removeModulesMenuItem;
+		private NostalgicToolStripMenuItem sortModulesMenuItem;
+		private NostalgicToolStripMenuItem moveModulesUpMenuItem;
+		private NostalgicToolStripMenuItem moveModulesDownMenuItem;
+		private NostalgicToolStripMenuItem moduleListSetSubSongMenuItem;
+		private NostalgicToolStripMenuItem moduleListClearSubSongMenuItem;
+		private ToolStripSeparator fileActionsSeparatorMenuItem;
+		private NostalgicToolStripMenuItem showInFileExplorerMenuItem;
+		private NostalgicToolStripMenuItem propertiesMenuItem;
+		private ModuleListListItem moduleListContextItem;
 
 		// Timer variables
 		private MainWindowSettings.TimeFormat timeFormat;
@@ -1048,6 +1060,7 @@ namespace Polycode.NostalgicPlayer.Client.GuiPlayer.Windows.MainWindow
 			// Module list
 			moduleList.SelectedIndexChanged += ModuleListControl_SelectedIndexChanged;
 			moduleList.MouseDoubleClick += ModuleListControl_MouseDoubleClick;
+			moduleList.MouseDown += ModuleListControl_MouseDown;
 			moduleList.KeyPress += ModuleListControl_KeyPress;
 			moduleList.DragDrop += ModuleListControl_DragDrop;
 
@@ -1932,6 +1945,129 @@ namespace Polycode.NostalgicPlayer.Client.GuiPlayer.Windows.MainWindow
 				// Load and play the selected module
 				LoadAndPlayModule(index);
 			}
+		}
+
+
+
+		/********************************************************************/
+		/// <summary>
+		/// User clicked a mouse button in the module list box.
+		/// If it is the right mouse button, show the context menu
+		/// </summary>
+		/********************************************************************/
+		private void ModuleListControl_MouseDown(object sender, MouseEventArgs e)
+		{
+			if (e.Button != MouseButtons.Right)
+				return;
+
+			int index = moduleList.IndexFromPoint(e.Location);
+			moduleListContextItem = index != -1 ? moduleList.Items[index] : null;
+
+			if ((index != -1) && !moduleList.SelectedIndexes.Contains(index))
+				moduleList.SelectedIndex = index;
+
+			moduleListContextMenu.Show(moduleList, e.Location);
+		}
+
+
+
+		/********************************************************************/
+		/// <summary>
+		/// Is called right before the module list context menu is opened
+		/// </summary>
+		/********************************************************************/
+		private void ModuleListContextMenu_Opening(object sender, CancelEventArgs e)
+		{
+			// Determine whether the menu was opened on a selected list item
+			IReadOnlyList<int> selectedIndexes = moduleList.SelectedIndexes;
+			bool hasSelection = (moduleListContextItem != null) && (selectedIndexes.Count > 0);
+
+			// Update the list editing actions based on the current items and selection
+			removeModulesMenuItem.Enabled = hasSelection;
+			sortModulesMenuItem.Enabled = moduleList.Items.Count > 0;
+			moveModulesUpMenuItem.Enabled = hasSelection && selectedIndexes.Any(index => (index > 0) && !selectedIndexes.Contains(index - 1));
+			moveModulesDownMenuItem.Enabled = hasSelection && selectedIndexes.Any(index => ((index + 1) < moduleList.Items.Count) && !selectedIndexes.Contains(index + 1));
+
+			// Update the default sub-song actions from the playback and selection state
+			moduleListSetSubSongMenuItem.Enabled = moduleHandler.IsModuleLoaded;
+			moduleListClearSubSongMenuItem.Enabled = hasSelection && moduleList.SelectedItems.Any(x => x.DefaultSubSong.HasValue);
+
+			// Hide unsupported Windows shell actions when running on Windows 10 S
+			bool fileActionsVisible = !Env.IsWindows10S;
+			fileActionsSeparatorMenuItem.Visible = fileActionsVisible;
+			showInFileExplorerMenuItem.Visible = fileActionsVisible;
+			propertiesMenuItem.Visible = fileActionsVisible;
+
+			// Enable file actions only for an existing local file selected from an item
+			string fileName = GetPhysicalFilePath(moduleListContextItem?.ListItem);
+			bool fileActionAvailable = hasSelection && fileActionsVisible && !string.IsNullOrEmpty(fileName) && File.Exists(fileName);
+
+			showInFileExplorerMenuItem.Enabled = fileActionAvailable;
+			propertiesMenuItem.Enabled = fileActionAvailable;
+		}
+
+
+
+		/********************************************************************/
+		/// <summary>
+		/// Is called when the user selects "Show in File Explorer"
+		/// </summary>
+		/********************************************************************/
+		private void ModuleListMenu_ShowInFileExplorer(object sender, EventArgs e)
+		{
+			string fileName = GetPhysicalFilePath(moduleListContextItem?.ListItem);
+			if (string.IsNullOrEmpty(fileName))
+				return;
+
+			try
+			{
+				WindowsShellHelper.ShowInFileExplorer(fileName);
+			}
+			catch (Exception ex)
+			{
+				ShowSimpleErrorMessage(ex.Message);
+			}
+		}
+
+
+
+		/********************************************************************/
+		/// <summary>
+		/// Is called when the user selects "Properties"
+		/// </summary>
+		/********************************************************************/
+		private void ModuleListMenu_Properties(object sender, EventArgs e)
+		{
+			string fileName = GetPhysicalFilePath(moduleListContextItem?.ListItem);
+			if (string.IsNullOrEmpty(fileName))
+				return;
+
+			try
+			{
+				WindowsShellHelper.ShowProperties(fileName);
+			}
+			catch (Exception ex)
+			{
+				ShowSimpleErrorMessage(ex.Message);
+			}
+		}
+
+
+
+		/********************************************************************/
+		/// <summary>
+		/// Return the physical file represented by the module list item
+		/// </summary>
+		/********************************************************************/
+		private static string GetPhysicalFilePath(IModuleListItem listItem)
+		{
+			if (listItem is SingleFileModuleListItem)
+				return listItem.Source;
+
+			if (listItem is ArchiveFileModuleListItem)
+				return ArchivePath.GetArchiveName(listItem.Source);
+
+			return null;
 		}
 
 
@@ -3190,6 +3326,7 @@ namespace Polycode.NostalgicPlayer.Client.GuiPlayer.Windows.MainWindow
 			CreateSortContextMenu();
 			CreateListContextMenu();
 			CreateDiskContextMenu();
+			CreateModuleListContextMenu();
 
 			// Set tooltip on all controls
 			SetTooltips();
@@ -3395,6 +3532,133 @@ namespace Polycode.NostalgicPlayer.Client.GuiPlayer.Windows.MainWindow
 			item.ImageName = nameof(IMainImages.Save);
 			item.Click += DiskMenu_SaveList;
 			diskContextMenu.Items.Add(item);
+		}
+
+
+
+		/********************************************************************/
+		/// <summary>
+		/// Create the module list context menu (right click an item within the module list)
+		/// </summary>
+		/********************************************************************/
+		private void CreateModuleListContextMenu()
+		{
+			// Note:  Context menu item filtering is done in the Opening event
+
+			moduleListContextMenu.Opening += ModuleListContextMenu_Opening;
+
+			// Add
+			NostalgicToolStripMenuItem addSubMenu = new NostalgicToolStripMenuItem(Resources.IDS_FAVORITE_BUTTON_ADD);
+			addSubMenu.ImageName = nameof(IMainImages.Add);
+			moduleListContextMenu.Items.Add(addSubMenu);
+
+			NostalgicToolStripMenuItem addItem = new NostalgicToolStripMenuItem(Resources.IDS_CONTEXTMENU_ADD_FILES);
+			addItem.ImageName = nameof(IMainImages.File);
+			addItem.Click += AddMenu_Files;
+			addSubMenu.DropDownItems.Add(addItem);
+
+			addItem = new NostalgicToolStripMenuItem(Resources.IDS_CONTEXTMENU_ADD_DIRECTORY);
+			addItem.ImageName = nameof(IMainImages.Directory);
+			addItem.Click += AddMenu_Directory;
+			addSubMenu.DropDownItems.Add(addItem);
+
+
+			// Remove
+			removeModulesMenuItem = new NostalgicToolStripMenuItem(Resources.IDS_FAVORITE_BUTTON_REMOVE);
+			removeModulesMenuItem.ImageName = nameof(IMainImages.Remove);
+			removeModulesMenuItem.Click += RemoveModuleButton_Click;
+			moduleListContextMenu.Items.Add(removeModulesMenuItem);
+
+
+			// Sort
+			sortModulesMenuItem = new NostalgicToolStripMenuItem(Resources.IDS_CONTEXTMENU_MODULELIST_SORT);
+			sortModulesMenuItem.ImageName = nameof(IMainImages.Sort);
+			moduleListContextMenu.Items.Add(sortModulesMenuItem);
+
+			NostalgicToolStripMenuItem sortItem = new NostalgicToolStripMenuItem(Resources.IDS_CONTEXTMENU_SORT_SORT_AZ);
+			sortItem.ImageName = nameof(IMainImages.AZ);
+			sortItem.Click += SortMenu_AZ;
+			sortModulesMenuItem.DropDownItems.Add(sortItem);
+
+			sortItem = new NostalgicToolStripMenuItem(Resources.IDS_CONTEXTMENU_SORT_SORT_ZA);
+			sortItem.ImageName = nameof(IMainImages.ZA);
+			sortItem.Click += SortMenu_ZA;
+			sortModulesMenuItem.DropDownItems.Add(sortItem);
+
+			sortItem = new NostalgicToolStripMenuItem(Resources.IDS_CONTEXTMENU_SORT_SHUFFLE);
+			sortItem.ImageName = nameof(IMainImages.Shuffle);
+			sortItem.Click += SortMenu_Shuffle;
+			sortModulesMenuItem.DropDownItems.Add(sortItem);
+
+			// Move
+			moveModulesUpMenuItem = new NostalgicToolStripMenuItem(Resources.IDS_CONTEXTMENU_MODULELIST_MOVE_UP);
+			moveModulesUpMenuItem.ImageName = nameof(IMainImages.MoveUp);
+			moveModulesUpMenuItem.Click += MoveModulesUpButton_Click;
+			moduleListContextMenu.Items.Add(moveModulesUpMenuItem);
+
+			moveModulesDownMenuItem = new NostalgicToolStripMenuItem(Resources.IDS_CONTEXTMENU_MODULELIST_MOVE_DOWN);
+			moveModulesDownMenuItem.ImageName = nameof(IMainImages.MoveDown);
+			moveModulesDownMenuItem.Click += MoveModulesDownButton_Click;
+			moduleListContextMenu.Items.Add(moveModulesDownMenuItem);
+
+
+			// Other actions
+			NostalgicToolStripMenuItem otherActionsSubMenu = new NostalgicToolStripMenuItem(Resources.IDS_CONTEXTMENU_MODULELIST_OTHER_ACTIONS);
+			otherActionsSubMenu.ImageName = nameof(IMainImages.List);
+			moduleListContextMenu.Items.Add(otherActionsSubMenu);
+
+			NostalgicToolStripMenuItem otherActionsItem = new NostalgicToolStripMenuItem(Resources.IDS_CONTEXTMENU_LIST_SELECT_ALL);
+			otherActionsItem.Click += ListMenu_SelectAll;
+			otherActionsSubMenu.DropDownItems.Add(otherActionsItem);
+
+			otherActionsItem = new NostalgicToolStripMenuItem(Resources.IDS_CONTEXTMENU_LIST_SELECT_NONE);
+			otherActionsItem.Click += ListMenu_SelectNone;
+			otherActionsSubMenu.DropDownItems.Add(otherActionsItem);
+
+			otherActionsSubMenu.DropDownItems.Add(new ToolStripSeparator());
+
+			moduleListSetSubSongMenuItem = new NostalgicToolStripMenuItem(Resources.IDS_CONTEXTMENU_LIST_SET_SUBSONG);
+			moduleListSetSubSongMenuItem.ImageName = nameof(IMainImages.SetSubSong);
+			moduleListSetSubSongMenuItem.Click += ListMenu_SetDefaultSubSong;
+			otherActionsSubMenu.DropDownItems.Add(moduleListSetSubSongMenuItem);
+
+			moduleListClearSubSongMenuItem = new NostalgicToolStripMenuItem(Resources.IDS_CONTEXTMENU_LIST_CLEAR_SUBSONG);
+			moduleListClearSubSongMenuItem.ImageName = nameof(IMainImages.ClearSubSong);
+			moduleListClearSubSongMenuItem.Click += ListMenu_ClearDefaultSubSong;
+			otherActionsSubMenu.DropDownItems.Add(moduleListClearSubSongMenuItem);
+
+
+			// Load/save
+			NostalgicToolStripMenuItem loadSaveSubMenu = new NostalgicToolStripMenuItem(Resources.IDS_CONTEXTMENU_MODULELIST_LOAD_SAVE);
+			loadSaveSubMenu.ImageName = nameof(IMainImages.Disk);
+			moduleListContextMenu.Items.Add(loadSaveSubMenu);
+
+			NostalgicToolStripMenuItem loadSaveItem = new NostalgicToolStripMenuItem(Resources.IDS_CONTEXTMENU_DISK_LOAD);
+			loadSaveItem.ImageName = nameof(IMainImages.Load);
+			loadSaveItem.Click += DiskMenu_LoadList;
+			loadSaveSubMenu.DropDownItems.Add(loadSaveItem);
+
+			loadSaveItem = new NostalgicToolStripMenuItem(Resources.IDS_CONTEXTMENU_DISK_APPEND);
+			loadSaveItem.Click += DiskMenu_AppendList;
+			loadSaveSubMenu.DropDownItems.Add(loadSaveItem);
+
+			loadSaveItem = new NostalgicToolStripMenuItem(Resources.IDS_CONTEXTMENU_DISK_SAVE);
+			loadSaveItem.ImageName = nameof(IMainImages.Save);
+			loadSaveItem.Click += DiskMenu_SaveList;
+			loadSaveSubMenu.DropDownItems.Add(loadSaveItem);
+
+
+			// File actions
+			fileActionsSeparatorMenuItem = new ToolStripSeparator();
+			moduleListContextMenu.Items.Add(fileActionsSeparatorMenuItem);
+
+			showInFileExplorerMenuItem = new NostalgicToolStripMenuItem(Resources.IDS_CONTEXTMENU_MODULELIST_SHOW_IN_FILE_EXPLORER);
+			showInFileExplorerMenuItem.Click += ModuleListMenu_ShowInFileExplorer;
+			moduleListContextMenu.Items.Add(showInFileExplorerMenuItem);
+
+			propertiesMenuItem = new NostalgicToolStripMenuItem(Resources.IDS_CONTEXTMENU_MODULELIST_PROPERTIES);
+			propertiesMenuItem.Click += ModuleListMenu_Properties;
+			moduleListContextMenu.Items.Add(propertiesMenuItem);
 		}
 
 

--- a/Source/Clients/NostalgicPlayer/Windows/ModuleInfoWindow/Pages/InfoPageControl.cs
+++ b/Source/Clients/NostalgicPlayer/Windows/ModuleInfoWindow/Pages/InfoPageControl.cs
@@ -3,9 +3,9 @@
 /* license of NostalgicPlayer is keep. See the LICENSE file for more          */
 /* information.                                                               */
 /******************************************************************************/
-using System.Diagnostics;
 using System.Windows.Forms;
 using Polycode.NostalgicPlayer.Client.GuiPlayer.Containers.Settings;
+using Polycode.NostalgicPlayer.Client.GuiPlayer.Windows;
 using Polycode.NostalgicPlayer.Client.GuiPlayer.Windows.MainWindow;
 using Polycode.NostalgicPlayer.Controls.Extensions;
 using Polycode.NostalgicPlayer.Kit.Containers;
@@ -265,7 +265,7 @@ namespace Polycode.NostalgicPlayer.Client.GuiPlayer.Windows.ModuleInfoWindow.Pag
 						fileName = ArchivePath.GetArchiveName(fileName);
 
 					// Start File Explorer and select the file
-					Process.Start("explorer.exe", $"/select,\"{fileName}\"");
+					WindowsShellHelper.ShowInFileExplorer(fileName);
 				}
 			}
 		}

--- a/Source/Clients/NostalgicPlayer/Windows/WindowsShellHelper.cs
+++ b/Source/Clients/NostalgicPlayer/Windows/WindowsShellHelper.cs
@@ -1,0 +1,48 @@
+/******************************************************************************/
+/* This source, or parts thereof, may be used in any software as long the     */
+/* license of NostalgicPlayer is keep. See the LICENSE file for more          */
+/* information.                                                               */
+/******************************************************************************/
+using System.Diagnostics;
+using System.IO;
+
+namespace Polycode.NostalgicPlayer.Client.GuiPlayer.Windows
+{
+	/// <summary>
+	/// Helper class for Windows shell operations
+	/// </summary>
+	internal static class WindowsShellHelper
+	{
+		/********************************************************************/
+		/// <summary>
+		/// Open File Explorer and select the given file
+		/// </summary>
+		/********************************************************************/
+		public static void ShowInFileExplorer(string fileName)
+		{
+			Process.Start("explorer.exe", $"/select,\"{fileName}\"");
+		}
+
+
+
+		/********************************************************************/
+		/// <summary>
+		/// Show the Windows properties dialog for the given file
+		/// </summary>
+		/********************************************************************/
+		public static void ShowProperties(string fileName)
+		{
+			string directoryName = Path.GetDirectoryName(fileName);
+			string fileNameOnly = Path.GetFileName(fileName);
+
+			Shell32.Shell shell = new Shell32.Shell();
+			Shell32.Folder folder = shell.NameSpace(directoryName);
+			Shell32.FolderItem folderItem = folder?.ParseName(fileNameOnly);
+
+			if (folderItem == null)
+				throw new FileNotFoundException(null, fileName);
+
+			folderItem.InvokeVerb("properties");
+		}
+	}
+}

--- a/Source/NostalgicPlayer.Controls/Lists/NostalgicModuleList.Designer.cs
+++ b/Source/NostalgicPlayer.Controls/Lists/NostalgicModuleList.Designer.cs
@@ -56,6 +56,7 @@
 			moduleListInternal.DragDrop += ListItemControl_DragDrop;
 			moduleListInternal.KeyPress += ListItemControl_KeyPress;
 			moduleListInternal.MouseDoubleClick += ListItemControl_MouseDoubleClick;
+			moduleListInternal.MouseDown += ListItemControl_MouseDown;
 			// 
 			// moduleListScrollBar
 			// 

--- a/Source/NostalgicPlayer.Controls/Lists/NostalgicModuleList.cs
+++ b/Source/NostalgicPlayer.Controls/Lists/NostalgicModuleList.cs
@@ -687,6 +687,18 @@ namespace Polycode.NostalgicPlayer.Controls.Lists
 		/// 
 		/// </summary>
 		/********************************************************************/
+		private void ListItemControl_MouseDown(object sender, MouseEventArgs e)
+		{
+			OnMouseDown(e);
+		}
+
+
+
+		/********************************************************************/
+		/// <summary>
+		/// 
+		/// </summary>
+		/********************************************************************/
 		private void ListItemControl_KeyPress(object sender, KeyPressEventArgs e)
 		{
 			OnKeyPress(e);

--- a/Source/NostalgicPlayer.Controls/Menus/NostalgicToolStripMenuItem.cs
+++ b/Source/NostalgicPlayer.Controls/Menus/NostalgicToolStripMenuItem.cs
@@ -26,7 +26,8 @@ namespace Polycode.NostalgicPlayer.Controls.Menus
 
 		private INostalgicImageBank imageBank;
 
-		private MethodInfo cachedImageProperty;
+		private PropertyInfo cachedImageProperty;
+		private MethodInfo cachedImageMethod;
 		private object cachedAreaObject;
 
 		/********************************************************************/
@@ -102,7 +103,10 @@ namespace Polycode.NostalgicPlayer.Controls.Menus
 		/********************************************************************/
 		internal Bitmap GetImage(Color color)
 		{
-			return cachedImageProperty?.Invoke(cachedAreaObject, [ color ]) as Bitmap;
+			if (cachedImageMethod != null)
+				return cachedImageMethod.Invoke(cachedAreaObject, [color]) as Bitmap;
+
+			return cachedImageProperty?.GetValue(cachedAreaObject) as Bitmap;
 		}
 
 
@@ -139,6 +143,7 @@ namespace Polycode.NostalgicPlayer.Controls.Menus
 		private void UpdateImageBinding()
 		{
 			cachedImageProperty = null;
+			cachedImageMethod = null;
 			cachedAreaObject = null;
 
 			if ((imageBank == null) || (imageArea == ImageBankArea.None) || string.IsNullOrEmpty(imageName))
@@ -149,7 +154,8 @@ namespace Polycode.NostalgicPlayer.Controls.Menus
 				return;
 
 			Type interfaceType = BankImageNameConverter.GetAreaInterfaceType(imageArea);
-			cachedImageProperty = interfaceType?.GetMethod(imageName, BindingFlags.Public | BindingFlags.Instance);
+			cachedImageMethod = interfaceType?.GetMethod(imageName, BindingFlags.Public | BindingFlags.Instance);
+			cachedImageProperty = interfaceType?.GetProperty(imageName, BindingFlags.Public | BindingFlags.Instance);
 		}
 
 


### PR DESCRIPTION
# What's included
* Initial module list context menu support 
* Added the module toolbar commands
* Added the File Explorer shell Rate context menu from Productivity Plus Pack if available on to the local user
* Added Show in File Explorer
* Added File Explorer Properties
* Should work on Windows S -- NOT tested
* Small factor to centralize shell related methods

# What's not included
* No UI to add additional shell context menus

# Tests
## Manual
**With no Productivity Plus Pack installed**
<img width="1186" height="516" alt="image" src="https://github.com/user-attachments/assets/92b1e11c-10a9-4743-88bb-1c2214644379" />

**With Productivity Plus Pack installed**
<img width="1180" height="513" alt="image" src="https://github.com/user-attachments/assets/a2363e72-d9a6-45f7-9550-fef79e5f8bc2" />


# References
## Productivity Plus Pack
* https://www.onegreatworld.com/products/productivity-plus-pack/