### PR TITLE
Playlist context menu: Updated docs and removed context menu move up and down entries

### DIFF
--- a/Documentation/howtouse.html
+++ b/Documentation/howtouse.html
@@ -329,7 +329,7 @@
 							</tr>
 						</table>
 
-						<p>If you have the <a href="https://www.onegreatworld.com/products/productivity-plus-pack/" target="_ppp">Productivity Plus Pack</a> installed you can rate the module from within NostalgicPlayer, so you can find your modules in File Explorer later based their rating.</p>
+						<p>If you have the <a href="https://www.onegreatworld.com/products/productivity-plus-pack/" target="_ppp">Productivity Plus Pack</a> installed you can rate the module from within NostalgicPlayer so you later can find your modules in File Explorer based on their rating.</p>
 						<br>
 						<img src="images/playlistcontextmenuwithppp.png" alt="Playlist context menu when Productivity Plus Pack is installed"/>
 						<br>

--- a/Documentation/howtouse.html
+++ b/Documentation/howtouse.html
@@ -313,6 +313,38 @@
 						</table>
 					</span>
 					<span>
+						<a name="playingtime"><h3>Context menu</h3></a>
+						<p>Right-click one or more modules in the playlist to see related actions.</p>
+						<br>
+						<img src="images/playlistcontextmenu.png" alt="Playlist context menu"/>
+						<br>
+						<table class="usage2table">
+							<tr>
+								<td>Show in File Explorer</td>
+								<td>Open File Explorer and selects the file for easy manipulation.</td>
+							</tr>
+							<tr>
+								<td>Properties</td>
+								<td>Open File Explorer properties.</td>
+							</tr>
+						</table>
+
+						<p>If you have the <a href="https://www.onegreatworld.com/products/productivity-plus-pack/" target="_ppp">Productivity Plus Pack</a> installed you can rate the module from within NostalgicPlayer, so you can find your modules in File Explorer later based their rating.</p>
+						<br>
+						<img src="images/playlistcontextmenuwithppp.png" alt="Playlist context menu when Productivity Plus Pack is installed"/>
+						<br>
+						<table class="usage2table">
+							<tr>
+								<td>Show in File Explorer</td>
+								<td>Open File Explorer and selects the module file.</td>
+							</tr>
+							<tr>
+								<td>Properties</td>
+								<td>Open File Explorer properties for the selected module.</td>
+							</tr>
+						</table>
+					</span>
+					<span>
 						<a name="playingtime"><h3>Playing time</h3></a>
 						<p>This area shows time information of all selected modules in playlist and total playing time of entire playlist.</p>
 						<p><b>NOTE:</b> Since playing time is calculated when module is loaded, total playing time may change as you load new modules.</p>

--- a/Documentation/howtouse.html
+++ b/Documentation/howtouse.html
@@ -320,6 +320,26 @@
 						<br>
 						<table class="usage2table">
 							<tr>
+								<td>Add</td>
+								<td>See <a href="#add">add module(s) to playlist</a> above.</td>
+							</tr>
+							<tr>
+								<td>Remove</td>
+								<td>See <a href="#remove">remove module(s) from playlist</a> above.</td>
+							</tr>
+							<tr>
+								<td>Sort</td>
+								<td>See <a href="#sort">sort / shuffle playlist</a> above.</td>
+							</tr>
+							<tr>
+								<td>Other actions</td>
+								<td>See <a href="#listitem">list item</a> above.</td>
+							</tr>
+							<tr>
+								<td>Load/save</td>
+								<td>See <a href="#list">playlist options</a> above.</td>
+							</tr>
+							<tr>
 								<td>Show in File Explorer</td>
 								<td>Open File Explorer and selects the file for easy manipulation.</td>
 							</tr>
@@ -335,12 +355,8 @@
 						<br>
 						<table class="usage2table">
 							<tr>
-								<td>Show in File Explorer</td>
-								<td>Open File Explorer and selects the module file.</td>
-							</tr>
-							<tr>
-								<td>Properties</td>
-								<td>Open File Explorer properties for the selected module.</td>
+								<td>Rate</td>
+								<td>See and choose a rating for the selected module(s).</td>
 							</tr>
 						</table>
 					</span>

--- a/Documentation/images/playlistcontextmenu.png
+++ b/Documentation/images/playlistcontextmenu.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:94fb14af9e86ecaf58f9b65b66ba3ef6d1d3bd6599a5ceee2df36a6b7f6323bd
+size 5206

--- a/Documentation/images/playlistcontextmenuwithppp.png
+++ b/Documentation/images/playlistcontextmenuwithppp.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b7a48899147cf1f4f571f8c79a38ee3c1c6be35d8dd7b983f52a87d2ebd989e5
+size 10639

--- a/Source/Clients/NostalgicPlayer/Resources.Designer.cs
+++ b/Source/Clients/NostalgicPlayer/Resources.Designer.cs
@@ -1443,24 +1443,6 @@ namespace Polycode.NostalgicPlayer.Client.GuiPlayer {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Move down.
-        /// </summary>
-        internal static string IDS_CONTEXTMENU_MODULELIST_MOVE_DOWN {
-            get {
-                return ResourceManager.GetString("IDS_CONTEXTMENU_MODULELIST_MOVE_DOWN", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Move up.
-        /// </summary>
-        internal static string IDS_CONTEXTMENU_MODULELIST_MOVE_UP {
-            get {
-                return ResourceManager.GetString("IDS_CONTEXTMENU_MODULELIST_MOVE_UP", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Other actions.
         /// </summary>
         internal static string IDS_CONTEXTMENU_MODULELIST_OTHER_ACTIONS {

--- a/Source/Clients/NostalgicPlayer/Resources.resx
+++ b/Source/Clients/NostalgicPlayer/Resources.resx
@@ -651,12 +651,6 @@ Formats supported:
   <data name="IDS_CONTEXTMENU_MODULELIST_PROPERTIES" xml:space="preserve">
     <value>Properties</value>
   </data>
-	<data name="IDS_CONTEXTMENU_MODULELIST_MOVE_DOWN" xml:space="preserve">
-    <value>Move down</value>
-  </data>
-	<data name="IDS_CONTEXTMENU_MODULELIST_MOVE_UP" xml:space="preserve">
-    <value>Move up</value>
-  </data>
 	<data name="IDS_CONTEXTMENU_MODULELIST_LOAD_SAVE" xml:space="preserve">
     <value>Load/save</value>
   </data>

--- a/Source/Clients/NostalgicPlayer/Windows/MainWindow/MainWindowForm.cs
+++ b/Source/Clients/NostalgicPlayer/Windows/MainWindow/MainWindowForm.cs
@@ -151,8 +151,6 @@ namespace Polycode.NostalgicPlayer.Client.GuiPlayer.Windows.MainWindow
 		private readonly List<ExplorerCommandToolStripMenu> moduleListExplorerCommandMenus = new List<ExplorerCommandToolStripMenu>();
 		private ModuleListItem moduleListContextItem = null;
 		private KryptonContextMenuItem contextMenuItemRemove = null;
-		private KryptonContextMenuItem contextMenuItemMoveUp = null;
-		private KryptonContextMenuItem contextMenuItemMoveDown = null;
 		private KryptonContextMenuItem contextMenuSortMenu = null;
 		private KryptonContextMenuItem contextMenuItemSetSubSong = null;
 		private KryptonContextMenuItem contextMenuItemClearSubSong = null;
@@ -3508,14 +3506,6 @@ namespace Polycode.NostalgicPlayer.Client.GuiPlayer.Windows.MainWindow
 
 
 
-			// Move
-			contextMenuItemMoveUp = new KryptonContextMenuItem(Resources.IDS_CONTEXTMENU_MODULELIST_MOVE_UP, Resources.IDB_MOVE_UP, MoveModulesUpButton_Click);
-			contextMenuItemMoveDown = new KryptonContextMenuItem(Resources.IDS_CONTEXTMENU_MODULELIST_MOVE_DOWN, Resources.IDB_MOVE_DOWN, MoveModulesDownButton_Click);
-			contextMenuItems.Items.Add(contextMenuItemMoveUp);
-			contextMenuItems.Items.Add(contextMenuItemMoveDown);
-
-
-
 			// Other actions
 			KryptonContextMenuItem moreMenu = new KryptonContextMenuItem(Resources.IDS_CONTEXTMENU_MODULELIST_OTHER_ACTIONS, Resources.IDB_LIST, null);
 
@@ -5969,8 +5959,6 @@ namespace Polycode.NostalgicPlayer.Client.GuiPlayer.Windows.MainWindow
 			// Update the list editing actions based on the current items and selection
 			contextMenuItemRemove.Enabled = hasSelection;
 			contextMenuSortMenu.Enabled = moduleListControl.Items.Count > 0;
-			contextMenuItemMoveUp.Enabled = hasSelection && selectedIndexes.Any(index => (index > 0) && !selectedIndexes.Contains(index - 1));
-			contextMenuItemMoveDown.Enabled = hasSelection && selectedIndexes.Any(index => ((index + 1) < moduleListControl.Items.Count) && !selectedIndexes.Contains(index + 1));
 
 			// Update the default sub-song actions from the playback and selection state
 			contextMenuItemSetSubSong.Enabled = moduleHandler.IsModuleLoaded;


### PR DESCRIPTION
# What's included
* Removed cluttering move up and move down context menu entries
* Updated the "How to use" documentation including 2 screenshots

# What's NOT included
* Documentation does not link or spell-out the context menu actions that are described above on the how to use page. @neumatho would you like me to include that?

# Tests
## Manual
Added Context menu section setting below "Playlist options" and above "Playing time"

<img width="729" height="973" alt="image" src="https://github.com/user-attachments/assets/b096e4cb-6035-4e93-be88-2c3d80bd033e" />

